### PR TITLE
Added font reset feature, font size clamp and made commands repeatable.

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -22,6 +22,10 @@ export default class FontSizeAdjuster extends Plugin {
 
 				if (typeof currentSize !== 'number') return false;
 
+				// updateFontSize() actually clamps font size to '10 <= size <= 30'
+				// so making font size doesn't go over 30px
+				if (currentSize >= 30) return false;
+
 				if (!checking) {
 					this.app.vault.setConfig('baseFontSize', currentSize + 1);
 					this.app.updateFontSize();
@@ -35,7 +39,11 @@ export default class FontSizeAdjuster extends Plugin {
 			name: 'Decrement font size',
 			checkCallback: (checking) => {
 				const currentSize = this.app.vault.getConfig('baseFontSize');
+
 				if (typeof currentSize !== 'number') return false;
+				// updateFontSize() actually clamps font size to '10 <= size <= 30'
+				// so making font size doesn't go under 10px
+				if (currentSize <= 10) return false;
 
 				if (!checking) {
 					this.app.vault.setConfig('baseFontSize', currentSize - 1);

--- a/src/main.ts
+++ b/src/main.ts
@@ -44,5 +44,23 @@ export default class FontSizeAdjuster extends Plugin {
 				return true;
 			}
 		});
+
+		this.addCommand({
+			id: 'reset-font-size',
+			name: 'Rest font size to default',
+			checkCallback: (checking: boolean) => {
+				const currentSize = this.app.vault.getConfig('baseFontSize');
+				if (typeof currentSize !== 'number') return false;
+
+				if (!checking) {
+					// default value for font-text is 16px
+					// https://docs.obsidian.md/Reference/CSS+variables/Foundations/Typography
+					this.app.vault.setConfig('baseFontSize', 16);
+					this.app.updateFontSize();
+				}
+				return true;
+			}
+
+		});
 	}
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -17,6 +17,7 @@ export default class FontSizeAdjuster extends Plugin {
 		this.addCommand({
 			id: 'increment-font-size',
 			name: 'Increment font size',
+			repeatable: true, // holding hotkey repeatedely trigger command
 			checkCallback: (checking) => {
 				const currentSize = this.app.vault.getConfig('baseFontSize');
 
@@ -37,6 +38,7 @@ export default class FontSizeAdjuster extends Plugin {
 		this.addCommand({
 			id: 'decrement-font-size',
 			name: 'Decrement font size',
+			repeatable: true, // holding hotkey repeatedely trigger command
 			checkCallback: (checking) => {
 				const currentSize = this.app.vault.getConfig('baseFontSize');
 


### PR DESCRIPTION
- Added Font reset command which resets to default value of 16px
- Made font size doesn't go over 30px or under 10px, which is based on the behaivor of `updateFontSize()` - `Math.clamp(e, 10, 30)`
- Made font increase/decrease command to be repeatable. Font size can be changed by holding user customized hotkeys.

Hi, I was looking for this kind of plugin so badly, I am glad I found it. I added some quality-of-life feautre and fixes, please look into them. Thank you.